### PR TITLE
adding config.php.example to have each user have their own environment for testing

### DIFF
--- a/final/.gitignore
+++ b/final/.gitignore
@@ -1,0 +1,1 @@
+config.php

--- a/final/.gitignore
+++ b/final/.gitignore
@@ -1,1 +1,2 @@
 config.php
+.DS_Store

--- a/final/config.php.example
+++ b/final/config.php.example
@@ -4,7 +4,7 @@ return [
   'ftp_user' => "FTP_USER",
   'ftp_pass' => "FTP_PASS",
   'ftp_port' => "21",
-  'domain' => 'FTP_DOMAIN',
+  'ftp_domain' => 'FTP_DOMAIN',
   'api_key' => 'API_KEY',
   'api_secret' => 'API_SECRET'
 ];

--- a/final/config.php.example
+++ b/final/config.php.example
@@ -1,0 +1,10 @@
+<?php
+return [
+  'ftp_server' => "FTP_SERVER",
+  'ftp_user' => "FTP_USER",
+  'ftp_pass' => "FTP_PASS",
+  'ftp_port' => "21",
+  'domain' => 'FTP_DOMAIN',
+  'api_key' => 'API_KEY',
+  'api_secret' => 'API_SECRET'
+];

--- a/final/ftp_upload.php
+++ b/final/ftp_upload.php
@@ -48,14 +48,14 @@ if (isset($_FILES['file'])) {
         $debug[] = "File uploaded successfully to: $remote_file";
 
         // Step 4: Call API with FTP file URL
-        $file_url = $config['ftp_domain'] . urlencode($file_name);
+        $file_url = $config['ftp_domain'] . "/uploads/" . urlencode($file_name);
         $api_key =  $config['api_key'];
         $api_secret =  $config['api_secret'];
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, "https://api.imagga.com/v2/tags?image_url=" . urlencode($file_url));
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_USERPWD, "$api_key:$api_secret");
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_USERPWD, "$api_key:$api_secret");      
 
         $response = curl_exec($ch);
         $curl_error = curl_error($ch);
@@ -64,6 +64,12 @@ if (isset($_FILES['file'])) {
         if ($response) {
             $debug[] = "API call successful for file: $file_url";
             $data = json_decode($response, true);
+
+            $debug[] = "Raw API Response: " . $response;
+
+            echo json_encode(['message' => 'API call debug info', 'debug' => $debug]);
+            exit;
+           
         } else {
             $debug[] = "API call failed: $curl_error";
             echo json_encode(['message' => 'API call failed', 'debug' => $debug]);

--- a/final/ftp_upload.php
+++ b/final/ftp_upload.php
@@ -2,6 +2,7 @@
 session_start();
 
 $debug = [];
+// $threshold = isset($_POST['threshold']) ? (float)$_POST['threshold'] : 50;
 
 if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
     echo json_encode(['message' => 'Unauthorized access', 'debug' => $debug]);
@@ -63,13 +64,7 @@ if (isset($_FILES['file'])) {
 
         if ($response) {
             $debug[] = "API call successful for file: $file_url";
-            $data = json_decode($response, true);
-
-            $debug[] = "Raw API Response: " . $response;
-
-            echo json_encode(['message' => 'API call debug info', 'debug' => $debug]);
-            exit;
-           
+            $data = json_decode($response, true);           
         } else {
             $debug[] = "API call failed: $curl_error";
             echo json_encode(['message' => 'API call failed', 'debug' => $debug]);
@@ -80,7 +75,9 @@ if (isset($_FILES['file'])) {
         // Step 5: Write metadata based on API response
         if (isset($data['result']['tags'])) {
             $tags = array_map(function($tag) {
-                return $tag['tag']['en'];
+                // if ($tag['confidence'] >= $threshold) {
+                //     return $tag['tag']['en'];
+                // }
             }, $data['result']['tags']);
             $description = implode(", ", $tags);
 

--- a/final/ftp_upload.php
+++ b/final/ftp_upload.php
@@ -83,17 +83,15 @@ if (isset($_FILES['file'])) {
                 }
             }
             
-            $description = implode(", ", $tags);
-                
+            $description = implode(", ", $tags);     
             $metadata_content = "Image Description: " . $description . "\nUploaded File Name: " . $file_name;
-        
+    
+            $remote_file = "uploads/" . pathinfo($file_name, PATHINFO_FILENAME) . "_metadata.txt";
             $local_upload = './uploads/';        
             $metadata_file = $local_upload . pathinfo($file_name, PATHINFO_FILENAME) . "_metadata.txt";
                 
             if (file_put_contents($metadata_file, $metadata_content) !== false) {
                 $debug[] = "Metadata file created successfully locally at: " . $metadata_file;
-
-                $remote_file = "uploads/" . pathinfo($file_name, PATHINFO_FILENAME) . "_metadata.txt";
 
                 if (ftp_put($ftp_conn, $remote_file, $metadata_file, FTP_ASCII)) {
                     $debug[] = "Metadata file uploaded successfully remotely to: $remote_file, deleting local copy";

--- a/final/ftp_upload.php
+++ b/final/ftp_upload.php
@@ -85,14 +85,11 @@ if (isset($_FILES['file'])) {
             
             $description = implode(", ", $tags);
                 
-            // Metadata content
             $metadata_content = "Image Description: " . $description . "\nUploaded File Name: " . $file_name;
         
             $local_upload = './uploads/';        
             $metadata_file = $local_upload . pathinfo($file_name, PATHINFO_FILENAME) . "_metadata.txt";
-        
-        
-            // Write metadata to the file
+                
             if (file_put_contents($metadata_file, $metadata_content) !== false) {
                 $debug[] = "Metadata file created successfully locally at: " . $metadata_file;
 
@@ -104,7 +101,6 @@ if (isset($_FILES['file'])) {
                         'message' => 'File and metadata uploaded successfully',
                         'tags' => $tags,
                         'description' => $description,
-                        'debug' => $debug
                     ]);
                 } else {
                     $debug[] = "Failed to remotely upload metadata file to: $remote_file";

--- a/final/ftp_upload.php
+++ b/final/ftp_upload.php
@@ -77,9 +77,7 @@ if (isset($_FILES['file'])) {
                 return $tag['tag']['en'];
             }, $data['result']['tags']);
             $description = implode(", ", $tags);
-        
-            $debug[] = "Collection of tags: " . $description;
-        
+                
             // Metadata content
             $metadata_content = "Image Description: " . $description . "\nUploaded File Name: " . $file_name;
         

--- a/final/ftp_upload.php
+++ b/final/ftp_upload.php
@@ -2,7 +2,6 @@
 session_start();
 
 $debug = [];
-// $threshold = isset($_POST['threshold']) ? (float)$_POST['threshold'] : 50;
 
 if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
     echo json_encode(['message' => 'Unauthorized access', 'debug' => $debug]);
@@ -64,7 +63,7 @@ if (isset($_FILES['file'])) {
 
         if ($response) {
             $debug[] = "API call successful for file: $file_url";
-            $data = json_decode($response, true);           
+            $data = json_decode($response, true);
         } else {
             $debug[] = "API call failed: $curl_error";
             echo json_encode(['message' => 'API call failed', 'debug' => $debug]);

--- a/final/ftp_upload.php
+++ b/final/ftp_upload.php
@@ -75,9 +75,7 @@ if (isset($_FILES['file'])) {
         // Step 5: Write metadata based on API response
         if (isset($data['result']['tags'])) {
             $tags = array_map(function($tag) {
-                // if ($tag['confidence'] >= $threshold) {
-                //     return $tag['tag']['en'];
-                // }
+                return $tag['tag']['en'];
             }, $data['result']['tags']);
             $description = implode(", ", $tags);
 

--- a/final/ftp_upload.php
+++ b/final/ftp_upload.php
@@ -9,10 +9,11 @@ if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
 }
 
 // FTP server details
-$ftp_server = "ftp.yourdomain.com";
-$ftp_port = 21;
-$ftp_user = "ftp_username";
-$ftp_pass = "ftp_password";
+$config = include 'config.php';
+$ftp_server = $config['ftp_server'];
+$ftp_port = $config['ftp_port'];
+$ftp_user = $config['ftp_user'];
+$ftp_pass = $config['ftp_pass'];
 
 if (isset($_FILES['file'])) {
     $file = $_FILES['file']['tmp_name'];
@@ -47,9 +48,9 @@ if (isset($_FILES['file'])) {
         $debug[] = "File uploaded successfully to: $remote_file";
 
         // Step 4: Call API with FTP file URL
-        $file_url = "https://yourdomain.com/uploads/" . urlencode($file_name);
-        $api_key = "IMAGGA_API_KEY";
-        $api_secret = "IMAGGA_API_SECRET";
+        $file_url = $config['ftp_domain'] . urlencode($file_name);
+        $api_key =  $config['api_key'];
+        $api_secret =  $config['api_secret'];
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, "https://api.imagga.com/v2/tags?image_url=" . urlencode($file_url));

--- a/final/js/app.js
+++ b/final/js/app.js
@@ -1,51 +1,51 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const dropArea = document.getElementById('drop-area');
-  const fileInput = document.getElementById('fileInput');
-  const imageUrlInput = document.getElementById('imageUrl');
-  const uploadOption = document.getElementById('uploadOption');
-  const urlOption = document.getElementById('urlOption');
-  const uploadSection = document.getElementById('uploadSection');
-  const urlSection = document.getElementById('urlSection');
-  const imagePreview = document.getElementById('imagePreview');
-  const debugWindow = document.getElementById('debug');
+document.addEventListener("DOMContentLoaded", () => {
+  const dropArea = document.getElementById("drop-area");
+  const fileInput = document.getElementById("fileInput");
+  const imageUrlInput = document.getElementById("imageUrl");
+  const uploadOption = document.getElementById("uploadOption");
+  const urlOption = document.getElementById("urlOption");
+  const uploadSection = document.getElementById("uploadSection");
+  const urlSection = document.getElementById("urlSection");
+  const imagePreview = document.getElementById("imagePreview");
+  const debugWindow = document.getElementById("debug");
 
   // Toggle input sections based on selected option
-  uploadOption.addEventListener('change', toggleInputOption);
-  urlOption.addEventListener('change', toggleInputOption);
+  uploadOption.addEventListener("change", toggleInputOption);
+  urlOption.addEventListener("change", toggleInputOption);
 
   function toggleInputOption() {
     if (uploadOption.checked) {
-      uploadSection.style.display = 'block';
-      urlSection.style.display = 'none';
+      uploadSection.style.display = "block";
+      urlSection.style.display = "none";
     } else {
-      uploadSection.style.display = 'none';
-      urlSection.style.display = 'block';
+      uploadSection.style.display = "none";
+      urlSection.style.display = "block";
     }
-    imagePreview.innerHTML = '';
-    debugWindow.innerHTML = '';
+    imagePreview.innerHTML = "";
+    debugWindow.innerHTML = "";
   }
 
   // Drag-and-drop functionality
-  ['dragenter', 'dragover'].forEach(eventName => {
+  ["dragenter", "dragover"].forEach((eventName) => {
     dropArea.addEventListener(eventName, highlight, false);
   });
-  ['dragleave', 'drop'].forEach(eventName => {
+  ["dragleave", "drop"].forEach((eventName) => {
     dropArea.addEventListener(eventName, unhighlight, false);
   });
-  dropArea.addEventListener('drop', handleDrop, false);
-  dropArea.addEventListener('click', () => fileInput.click(), false);
-  fileInput.addEventListener('change', handleFiles, false);
+  dropArea.addEventListener("drop", handleDrop, false);
+  dropArea.addEventListener("click", () => fileInput.click(), false);
+  fileInput.addEventListener("change", handleFiles, false);
 
   function highlight(e) {
     e.preventDefault();
     e.stopPropagation();
-    dropArea.classList.add('highlight');
+    dropArea.classList.add("highlight");
   }
 
   function unhighlight(e) {
     e.preventDefault();
     e.stopPropagation();
-    dropArea.classList.remove('highlight');
+    dropArea.classList.remove("highlight");
   }
 
   function handleDrop(e) {
@@ -62,69 +62,69 @@ document.addEventListener('DOMContentLoaded', () => {
     if (file) {
       // Display the image preview
       const reader = new FileReader();
-      reader.onload = function(e) {
+      reader.onload = function (e) {
         imagePreview.innerHTML = `<img src="${e.target.result}" alt="Uploaded Image">`;
       };
       reader.readAsDataURL(file);
-      dropArea.querySelector('p').textContent = `File Selected: ${file.name}`;
+      dropArea.querySelector("p").textContent = `File Selected: ${file.name}`;
     }
   }
 });
 
 function processImage() {
-  const threshold = document.getElementById('threshold').value;
-  const progress = document.getElementById('progress');
-  const debugWindow = document.getElementById('debug');
-  const tagsContainer = document.getElementById('tags-container');
-  const imagePreview = document.getElementById('imagePreview');
+  const threshold = document.getElementById("threshold").value;
+  const progress = document.getElementById("progress");
+  const debugWindow = document.getElementById("debug");
+  const tagsContainer = document.getElementById("tags-container");
+  const imagePreview = document.getElementById("imagePreview");
 
-  const uploadOption = document.getElementById('uploadOption');
-  const fileInput = document.getElementById('fileInput');
-  const imageUrlInput = document.getElementById('imageUrl');
+  const uploadOption = document.getElementById("uploadOption");
+  const fileInput = document.getElementById("fileInput");
+  const imageUrlInput = document.getElementById("imageUrl");
 
   // Show progress indicator
-  progress.style.display = 'block';
+  progress.style.display = "block";
 
   // Clear previous debug messages and tags
-  debugWindow.innerHTML = '';
-  tagsContainer.innerHTML = '';
+  debugWindow.innerHTML = "";
+  tagsContainer.innerHTML = "";
 
   const formData = new FormData();
-  formData.append('threshold', threshold);
-  formData.append('inputOption', uploadOption.checked ? 'upload' : 'url');
+  formData.append("threshold", threshold);
+  formData.append("inputOption", uploadOption.checked ? "upload" : "url");
 
   if (uploadOption.checked) {
     if (!fileInput.files[0]) {
-      alert('Please select an image file.');
-      progress.style.display = 'none';
+      alert("Please select an image file.");
+      progress.style.display = "none";
       return;
     }
-    formData.append('file', fileInput.files[0]);
+    formData.append("file", fileInput.files[0]);
   } else {
     const imageUrl = imageUrlInput.value.trim();
     if (!imageUrl) {
-      alert('Please enter an image URL.');
-      progress.style.display = 'none';
+      alert("Please enter an image URL.");
+      progress.style.display = "none";
       return;
     }
-    formData.append('imageUrl', imageUrl);
+    formData.append("imageUrl", imageUrl);
   }
 
-  fetch('process_image.php', { method: 'POST', body: formData })
-    .then(response => response.json())
-    .then(data => {
+  fetch("process_image.php", { method: "POST", body: formData })
+    .then((response) => response.json())
+    .then((data) => {
       // Hide progress indicator
-      progress.style.display = 'none';
+      progress.style.display = "none";
 
       if (data.error) {
         // Display error in debug window
-        const p = document.createElement('p');
+        const p = document.createElement("p");
         p.textContent = data.error;
         debugWindow.appendChild(p);
       } else {
         // Display debug messages
-        data.debug.forEach(msg => {
-          const p = document.createElement('p');
+        data.debug.forEach((msg) => {
+          const p = document.createElement("p");
           p.textContent = msg;
           debugWindow.appendChild(p);
         });
@@ -135,31 +135,33 @@ function processImage() {
         }
 
         // Display tags for selection
-        const form = document.createElement('form');
-        form.id = 'tagsForm';
+        const form = document.createElement("form");
+        form.id = "tagsForm";
 
-        const ul = document.createElement('ul');
-        ul.className = 'tag-list';
+        const ul = document.createElement("ul");
+        ul.className = "tag-list";
 
-        data.tags.forEach(tag => {
-          const li = document.createElement('li');
-          const checkbox = document.createElement('input');
-          checkbox.type = 'checkbox';
-          checkbox.name = 'tags[]';
+        data.tags.forEach((tag) => {
+          const li = document.createElement("li");
+          const checkbox = document.createElement("input");
+          checkbox.type = "checkbox";
+          checkbox.name = "tags[]";
           checkbox.value = tag.tag;
           checkbox.checked = true;
 
-          const label = document.createElement('label');
-          label.textContent = `${tag.tag} (Confidence: ${tag.confidence.toFixed(2)}%)`;
+          const label = document.createElement("label");
+          label.textContent = `${tag.tag} (Confidence: ${tag.confidence.toFixed(
+            2
+          )}%)`;
 
           li.appendChild(checkbox);
           li.appendChild(label);
           ul.appendChild(li);
         });
 
-        const downloadButton = document.createElement('button');
-        downloadButton.type = 'button';
-        downloadButton.textContent = 'Download Image with Metadata';
+        const downloadButton = document.createElement("button");
+        downloadButton.type = "button";
+        downloadButton.textContent = "Download Image with Metadata";
         downloadButton.onclick = downloadImage;
 
         form.appendChild(ul);
@@ -168,42 +170,44 @@ function processImage() {
       }
 
       // Log data to console
-      console.log('Response Data:', data);
+      console.log("Response Data:", data);
     })
-    .catch(error => {
-      progress.style.display = 'none';
-      console.error('Error:', error);
-      const p = document.createElement('p');
+    .catch((error) => {
+      progress.style.display = "none";
+      console.error("Error:", error);
+      const p = document.createElement("p");
       p.textContent = `Error: ${error}`;
       debugWindow.appendChild(p);
     });
 }
 
 function downloadImage() {
-  const form = document.getElementById('tagsForm');
+  const form = document.getElementById("tagsForm");
   const formData = new FormData(form);
 
-  fetch('embed_metadata.php', { method: 'POST', body: formData })
-    .then(response => {
+  fetch("embed_metadata.php", { method: "POST", body: formData })
+    .then((response) => {
       if (!response.ok) {
-        return response.text().then(text => { throw new Error(text) });
+        return response.text().then((text) => {
+          throw new Error(text);
+        });
       }
       return response.blob();
     })
-    .then(blob => {
+    .then((blob) => {
       // Create a link to download the file
       const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
+      const a = document.createElement("a");
       a.href = url;
-      a.download = 'modified_image.jpg';
+      a.download = "modified_image.jpg";
       document.body.appendChild(a);
       a.click();
       a.remove();
     })
-    .catch(error => {
-      console.error('Error:', error);
-      const debugWindow = document.getElementById('debug');
-      const p = document.createElement('p');
+    .catch((error) => {
+      console.error("Error:", error);
+      const debugWindow = document.getElementById("debug");
+      const p = document.createElement("p");
       p.textContent = `Error: ${error.message}`;
       debugWindow.appendChild(p);
     });

--- a/final/process_image.php
+++ b/final/process_image.php
@@ -39,8 +39,9 @@ if ($inputOption === 'upload' && isset($_FILES['file']) && $_FILES['file']['erro
   $debug[] = "File uploaded successfully: $destPath";
 
   // Imagga API credentials
-  $api_key = 'acc_74179c62baa1fe3';
-  $api_secret = 'b5d57bf2b166c425951dda16671004';
+  $config = include 'config.php';
+  $api_key = $config['api_key'];
+  $api_secret = $config['api_secret'];
 
   // Prepare the image for the API call
   $imageData = base64_encode(file_get_contents($destPath));
@@ -85,8 +86,8 @@ if ($inputOption === 'upload' && isset($_FILES['file']) && $_FILES['file']['erro
   }
 
   // Imagga API credentials
-  $api_key = 'acc_74179c62baa1fe3';
-  $api_secret = '72b5d57bf2b166c425951dda16671004';
+  $api_key = $config['api_key'];
+  $api_secret = $config['api_secret'];
 
   // Call the Imagga API with the image URL
   $ch = curl_init();


### PR DESCRIPTION
- added a config.php.example template
- each user will need to create a local config.php file (that is within .gitignore to prevent uploading credentials)
- process_image.php works as expected with creating copy of image within local uploads and fetching metadata from imagga api
- however ftp_upload.php doesn't work fully as expected; it does upload the image to siteground (you'll need to create the /uploads folder within the existing public_html folder). The code goes to the else condition within Step 5 of the page. 
e.g. I'm getting the 'No tags found in API response' debug message. 